### PR TITLE
Fixes 'containerize' example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,5 +46,5 @@ Whether to run Snakemake or to generate a container image specification (in the 
   uses: snakemake/snakemake-github-action@v1
   with:
     snakefile: 'workflow/Snakefile'
-    run: 'containerize'
+    task: 'containerize'
 ```


### PR DESCRIPTION
The README incorrectly uses a `run:` key, when it should be `task:`. This PR corrects it.