### PR TITLE
chore: trigger new release to pull in latest snakemake

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Whether to run Snakemake or to generate a container image specification (in the 
 
 Whether used disk space shall be printed if Snakemake fails. Can be either `true` or `false` (default: `false`).
 
+
 ## Example usage
 
 ```yaml


### PR DESCRIPTION
Currently, the snakemake-github-action seems to pull in a broken version of snakemake, with a bug that has since been fixed. So simply pulling in the latest release should fix this.

Current error message when using module import:
```
Rule convert_pfam is not defined in this workflow.
```

See e.g. here:
https://github.com/snakemake-workflows/rna-seq-kallisto-sleuth/actions/runs/5865262889/job/15901825940#step:4:18