### PR TITLE
fix: bring back execution of `stagein:`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -88,6 +88,7 @@ runs:
       if: ${{ inputs.task == 'run' }}
       shell: bash -el {0}
       run: |
+        ${{ input.stagein }}
         snakemake --directory ${{ inputs.directory }} --snakefile ${{ inputs.snakefile }} --show-failed-logs ${{ inputs.args }}
         if [[ "$?" -ne 0 ]]; then
           if [[ ${{ inputs.show-disk-usage-on-error }} = true ]]; then

--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ runs:
       if: ${{ inputs.task == 'run' }}
       shell: bash -el {0}
       run: |
-        ${{ input.stagein }}
+        ${{ inputs.stagein }}
         snakemake --directory ${{ inputs.directory }} --snakefile ${{ inputs.snakefile }} --show-failed-logs ${{ inputs.args }}
         if [[ "$?" -ne 0 ]]; then
           if [[ ${{ inputs.show-disk-usage-on-error }} = true ]]; then


### PR DESCRIPTION
It seems like the update to a composite action removed any use of the `inputs.stagein` functionality. This pull request attempt to bring it back.

Not sure if the containerize step also needs to run this:
https://github.com/snakemake/snakemake-github-action/compare/master...fix/revive-stagein?quick_pull=1#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R106

And for cross-reference, we noticed that stagein was simply not run on this CI:
https://github.com/ncbench/ncbench-workflow/actions/runs/14260687485/job/39971417393

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced an optional input parameter `stagein` that allows users to define additional preparatory steps before the main workflow execution, enhancing control over the process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->