### PR TITLE
fix: defunct release-please action

### DIFF
--- a/.github/workflows/conventional-prs.yml
+++ b/.github/workflows/conventional-prs.yml
@@ -1,4 +1,4 @@
-name: PR
+name: Lint PR
 on:
   pull_request_target:
     types:
@@ -7,10 +7,14 @@ on:
       - edited
       - synchronize
 
+permissions:
+  pull-requests: read
+
 jobs:
-  title-format:
+  main:
+    name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v3.4.0
+      - uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/conventional-prs.yml
+++ b/.github/workflows/conventional-prs.yml
@@ -7,13 +7,12 @@ on:
       - edited
       - synchronize
 
-permissions:
-  pull-requests: read
-
 jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
     steps:
       - uses: amannn/action-semantic-pull-request@v6
         env:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,33 +3,18 @@ on:
     branches:
       - master
 
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
 name: release-please
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-
-      - uses: GoogleCloudPlatform/release-please-action@v2
-        id: release
+      - uses: googleapis/release-please-action@v4
         with:
-          release-type: go # just no update of version anywhere needed
-          package-name: ${{env.ACTION_NAME}}
-
-      - uses: actions/checkout@v2
-        if: ${{ steps.release.outputs.release_created }}
-
-      - name: tag major and minor versions
-        if: ${{ steps.release.outputs.release_created }}
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git remote add gh-token "https://${{ secrets.GITHUB_TOKEN }}@github.com/google-github-actions/release-please-action.git"
-          git tag -d v${{ steps.release.outputs.major }} || true
-          git tag -d v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} || true
-          git push origin :v${{ steps.release.outputs.major }} || true
-          git push origin :v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} || true
-          git tag -a v${{ steps.release.outputs.major }} -m "Release v${{ steps.release.outputs.major }}"
-          git tag -a v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} -m "Release v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}"
-          git push origin v${{ steps.release.outputs.major }}
-          git push origin v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          release-type: go # just keep a changelog, no version anywhere outside of git tags

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: go # just keep a changelog, no version anywhere outside of git tags
+      - uses: actions/checkout@v4
+      - name: tag major and minor versions
+        if: ${{ steps.release.outputs.release_created }}
+        run: |
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git remote add gh-token "https://${{ secrets.GITHUB_TOKEN }}@github.com/googleapis/release-please-action.git"
+          git tag -d v${{ steps.release.outputs.major }} || true
+          git tag -d v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} || true
+          git push origin :v${{ steps.release.outputs.major }} || true
+          git push origin :v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} || true
+          git tag -a v${{ steps.release.outputs.major }} -m "Release v${{ steps.release.outputs.major }}"
+          git tag -a v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }} -m "Release v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}"
+          git push origin v${{ steps.release.outputs.major }}
+          git push origin v${{ steps.release.outputs.major }}.${{ steps.release.outputs.minor }}

--- a/README.md
+++ b/README.md
@@ -32,25 +32,25 @@ Whether used disk space shall be printed if Snakemake fails. Can be either `true
 
 ```yaml
 - name: Linting
-  uses: snakemake/snakemake-github-action@v1
+  uses: snakemake/snakemake-github-action@v2
   with:
-    directory: '.test'
-    snakefile: 'workflow/Snakefile'
-    args: '--lint'
+    directory: ".test"
+    snakefile: "workflow/Snakefile"
+    args: "--lint"
 
 - name: Testing
   uses: snakemake/snakemake-github-action@v2
   with:
-    directory: '.test'
-    snakefile: 'workflow/Snakefile'
-    args: '--cores 1 --sdm conda --conda-cleanup-pkgs cache'
-    stagein: '' # additional preliminary commands to run (can be multiline)
+    directory: ".test"
+    snakefile: "workflow/Snakefile"
+    args: "--cores 1 --sdm conda --conda-cleanup-pkgs cache"
+    stagein: "" # additional preliminary commands to run (can be multiline)
     show-disk-usage-on-error: true
-
 
 - name: Create container file
   uses: snakemake/snakemake-github-action@v2
   with:
-    snakefile: 'workflow/Snakefile'
-    task: 'containerize'
+    directory: ".test"
+    snakefile: "workflow/Snakefile"
+    task: "containerize"
 ```


### PR DESCRIPTION
- found out with the previous PR that the current `release-please` action is not working anymore :-(
- this PR updates the release-please and conventional-prs actions to latest version
- also adds the missing mandatory `directory` in the README example

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved PR validation: renamed job/display, expanded triggers, added permissions and updated action versions for PR linting.
  * Streamlined release automation: migrated to the newer release action, switched to token-based auth, updated checkout and tagging flow, and consolidated permissions.

* **Documentation**
  * Updated CI example snippets to newer action versions and normalized YAML formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->