### PR TITLE
fix: check if miniconda is present before installation, closes #47

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -73,8 +73,18 @@ runs:
           - snakemake ==${{ inputs.snakemake-version }}
         EOF
 
+    - name: Check if miniconda is already installed
+      id: check-miniconda
+      shell: bash -el {0}
+      run: |
+        if [ -d "/home/runner/miniconda3" ]; then
+          echo "installed=true" >> $GITHUB_OUTPUT
+        else
+          echo "installed=false" >> $GITHUB_OUTPUT
+        fi
+
     - name: Setup conda
-      if: ${{ !hashFiles('/home/runner/miniconda3/condabin/conda') }}
+      if: steps.check-miniconda.outputs.installed == 'false'
       uses: conda-incubator/setup-miniconda@v3
       with:
         channels: conda-forge,bioconda

--- a/action.yml
+++ b/action.yml
@@ -77,7 +77,7 @@ runs:
       id: check-miniconda
       shell: bash -el {0}
       run: |
-        if [ -d "/home/runner/miniconda3" ]; then
+        if [ -d "$HOME/miniconda3" ]; then
           echo "installed=true" >> $GITHUB_OUTPUT
         else
           echo "installed=false" >> $GITHUB_OUTPUT
@@ -92,7 +92,6 @@ runs:
         miniforge-version: latest
         environment-file: .snakemake.environment.yaml
         activate-environment: snakemake
-        installation-dir: /home/runner/miniconda3
 
     - name: Display snakemake version
       shell: bash -el {0}

--- a/action.yml
+++ b/action.yml
@@ -74,7 +74,7 @@ runs:
         EOF
 
     - name: Setup conda
-      if: ${{ !hashFiles('/home/runner/miniconda3/.condarc') }}
+      if: ${{ !hashFiles('/home/runner/miniconda3/condabin/conda') }}
       uses: conda-incubator/setup-miniconda@v3
       with:
         channels: conda-forge,bioconda

--- a/action.yml
+++ b/action.yml
@@ -74,6 +74,7 @@ runs:
         EOF
 
     - name: Setup conda
+      if: ${{ !hashFiles('/home/runner/miniconda3/.condarc') }}
       uses: conda-incubator/setup-miniconda@v3
       with:
         channels: conda-forge,bioconda
@@ -81,6 +82,7 @@ runs:
         miniforge-version: latest
         environment-file: .snakemake.environment.yaml
         activate-environment: snakemake
+        installation-dir: /home/runner/miniconda3
 
     - name: Display snakemake version
       shell: bash -el {0}


### PR DESCRIPTION
- closes #47 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Conda setup now pre-detects an existing Miniconda installation and skips reinstallation when present.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->