### PR TITLE
fix: pin miniforge to working version `25.9.1`

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -78,7 +78,7 @@ runs:
       with:
         channels: conda-forge,bioconda
         channel-priority: strict
-        miniforge-version: 25.9.1-0 # TODO: set back to "latest" once this issue in the conda-libmamba-solver is patched and/or released: https://github.com/conda/conda-libmamba-solver/issues/798
+        miniforge-version: 25.9.1-0 # TODO: set back to "latest" once this issue in the conda installer (template) is fixed and released: https://github.com/conda/constructor/pull/1135
         environment-file: .snakemake.environment.yaml
         activate-environment: snakemake
 

--- a/action.yml
+++ b/action.yml
@@ -78,7 +78,7 @@ runs:
       with:
         channels: conda-forge,bioconda
         channel-priority: strict
-        miniforge-version: 25.9.1 # TODO: set back to "latest" once this issue in the conda-libmamba-solver is patched and/or released: https://github.com/conda/conda-libmamba-solver/issues/798
+        miniforge-version: 25.9.1-0 # TODO: set back to "latest" once this issue in the conda-libmamba-solver is patched and/or released: https://github.com/conda/conda-libmamba-solver/issues/798
         environment-file: .snakemake.environment.yaml
         activate-environment: snakemake
 

--- a/action.yml
+++ b/action.yml
@@ -78,7 +78,7 @@ runs:
       with:
         channels: conda-forge,bioconda
         channel-priority: strict
-        miniforge-version: latest
+        miniforge-version: 25.9.1 # TODO: set back to "latest" once this issue in the conda-libmamba-solver is patched and/or released: https://github.com/conda/conda-libmamba-solver/issues/798
         environment-file: .snakemake.environment.yaml
         activate-environment: snakemake
 


### PR DESCRIPTION
Basically, this is only until this problem's fix is released in `conda-libmamba-solver`, probably via the `miniforge` installer: https://github.com/conda/constructor/pull/1135

The issue that I am seeing, which this pinning should solve, is this error upon trying to re-install miniforge a second time during a GitHub Action run:
```
Running installer...
  /usr/bin/bash /home/runner/work/_temp/8b4dfb06-0e2d-4654-a587-7651f953ce7f.sh -f -b -p /home/runner/miniconda3
  PREFIX=/home/runner/miniconda3
  Unpacking bootstrapper...
  Warning: ln: failed to create symbolic link '/home/runner/miniconda3/_conda': File exists
  
  ln: failed to create symbolic link '/home/runner/miniconda3/_conda': File exists
Error: The process '/usr/bin/bash' failed with exit code 1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned the conda setup to a specific stable version (temporarily) to improve build reliability; added an inline TODO noting this is a temporary measure and referencing a known issue.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->