### PR TITLE
feat: allow to use custom snakemake branch instead of conda version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,14 @@ jobs:
           snakefile: .test/Snakefile
           args: "--cores 1"
 
+      - name: Test run branch
+        uses: ./
+        with:
+          directory: .test
+          snakefile: .test/Snakefile
+          args: "--cores 1"
+          snakemake-branch: "main"
+
       - name: Test containerize
         uses: ./
         with:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ Whether to run Snakemake or to generate a container image specification (in the 
 
 Whether used disk space shall be printed if Snakemake fails. Can be either `true` or `false` (default: `false`).
 
+### `snakemake-version`
+
+Snakemake version to install from conda. Default `*` (latest available version from the configured channels).
+
+### `snakemake-branch`
+
+Optional Snakemake git branch to install from `https://github.com/snakemake/snakemake`. If set, this takes precedence over `snakemake-version` and Snakemake is installed from source via pip.
+
 ## Example usage
 
 ```yaml
@@ -46,6 +54,14 @@ Whether used disk space shall be printed if Snakemake fails. Can be either `true
     args: "--cores 1 --sdm conda --conda-cleanup-pkgs cache"
     stagein: "" # additional preliminary commands to run (can be multiline)
     show-disk-usage-on-error: true
+
+- name: Testing with custom Snakemake branch
+  uses: snakemake/snakemake-github-action@v2
+  with:
+    directory: ".test"
+    snakefile: "workflow/Snakefile"
+    args: "--cores 1 --sdm conda --conda-cleanup-pkgs cache"
+    snakemake-branch: main
 
 - name: Create container file
   uses: snakemake/snakemake-github-action@v2

--- a/action.yml
+++ b/action.yml
@@ -95,7 +95,7 @@ runs:
       with:
         channels: conda-forge,bioconda
         channel-priority: strict
-        miniforge-version: 25.9.1-0 # TODO: set back to "latest" once this issue in the conda installer (template) is fixed and released: https://github.com/conda/constructor/pull/1135
+        miniforge-version: latest
         environment-file: .snakemake.environment.yaml
         activate-environment: snakemake
 

--- a/action.yml
+++ b/action.yml
@@ -29,15 +29,22 @@ inputs:
   show-disk-usage-on-error:
     description: Whether to return the used disk space on failing.
     required: false
-    default: false
+    default: "false"
   snakemake-version:
-    description: Snakemake version to use. If not specified, uses latest version. Pin a specific version (e.g., '8.25.5') for reproducibility.
+    description: |
+      Snakemake version to use. If not specified, uses latest version. Pin a specific version (e.g., '8.25.5') for reproducibility.
     required: false
     default: "*"
+  snakemake-branch:
+    description: |
+      Optional Snakemake git branch to install from https://github.com/snakemake/snakemake.
+      If set, this takes precedence over snakemake-version and Snakemake is installed via pip.
+    required: false
+    default: ""
   install-apptainer:
     description: Install Apptainer (true/false)
     required: false
-    default: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -70,8 +77,18 @@ runs:
           - bioconda
           - nodefaults
         dependencies:
+        EOF
+
+        if [[ -n "${{ inputs.snakemake-branch }}" ]]; then
+          cat <<EOF >> .snakemake.environment.yaml
+          - python
+          - pip
+        EOF
+        else
+          cat <<EOF >> .snakemake.environment.yaml
           - snakemake ==${{ inputs.snakemake-version }}
         EOF
+        fi
 
     - name: Setup conda
       uses: conda-incubator/setup-miniconda@v3
@@ -81,6 +98,12 @@ runs:
         miniforge-version: 25.9.1-0 # TODO: set back to "latest" once this issue in the conda installer (template) is fixed and released: https://github.com/conda/constructor/pull/1135
         environment-file: .snakemake.environment.yaml
         activate-environment: snakemake
+
+    - name: Install snakemake from git branch
+      if: ${{ inputs.snakemake-branch != '' }}
+      shell: bash -el {0}
+      run: |
+        python -m pip install "git+https://github.com/snakemake/snakemake@${{ inputs.snakemake-branch }}"
 
     - name: Display snakemake version
       shell: bash -el {0}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Snakemake version selection from conda channels
  * Added support for installing Snakemake from a specific git branch, with precedence over version selection

* **Documentation**
  * Updated documentation with new input parameters and usage examples

* **Chores**
  * Enhanced CI testing with branch-targeted test execution
  * Updated conda environment configuration defaults

<!-- end of auto-generated comment: release notes by coderabbit.ai -->